### PR TITLE
Mouse click focus before adding RT to room

### DIFF
--- a/the_room.js
+++ b/the_room.js
@@ -96,6 +96,10 @@ const createRoom = async (page, roomName) => {
 
 const addRT = async (page) => {
   await page.waitForTimeout(3000);
+  
+  // Refocus on chat
+  await page.mouse.click(0, 0);
+  
   // Add RespectTables
   // Open room menu
   await page.keyboard.down(metaKey);


### PR DESCRIPTION
Gchat apparently updated and was failing to add RespectTables to rooms. Adding focus apparently fixes it so the menu can be opened and RT added.